### PR TITLE
Add support for ARM-based Broadcom BCM63xx xDSL SoCs

### DIFF
--- a/board-bcm63xx.c
+++ b/board-bcm63xx.c
@@ -1,0 +1,74 @@
+#include "atags.h"
+#include "board.h"
+#include "dtbs.h"
+#include "print.h"
+#include "register.h"
+#include "types.h"
+
+extern u32 _binary_input_zImage_start;
+extern u32 _binary_dtbs_bin_start;
+
+struct board board;
+
+struct bcm63xx_board {
+	u32		chip_id;
+	const char	*compatible;
+};
+
+static struct bcm63xx_board boards[] = {
+	{
+		.chip_id	= 0x63138,
+		.compatible	= "brcm,bcm63138",
+	},
+	{ 0, NULL }	/* sentinel */
+};
+
+static void panic(void)
+{
+	while (1)
+		;
+}
+
+/* Physical address of the INT_REVID register */
+#define INT_REVID_REG	0xfffe8000
+#define  CHIP_ID_SHIFT	12
+
+static u32 get_chip_id()
+{
+	return readl(INT_REVID_REG) >> CHIP_ID_SHIFT;
+}
+
+struct board *match_board(u32 machid, const struct tag *tags)
+{
+	struct bcm63xx_board *bcm_board;
+	u32 chip_id;
+
+	chip_id = get_chip_id();
+
+	putstr("Found a Broadcom BCM");
+	printhex(chip_id);
+	putstr(" chip\n");
+
+	for (bcm_board = boards; bcm_board->chip_id; bcm_board++) {
+		if (bcm_board->chip_id == chip_id)
+			break;
+	}
+
+	if (bcm_board->compatible == NULL) {
+		putstr("ERROR MATCHING BOARD!\n");
+		panic(); /* doesn't return */
+	}
+
+	board.kernel = &_binary_input_zImage_start;
+	board.compatible = bcm_board->compatible;
+	board.dtb = find_dtb(&_binary_dtbs_bin_start, bcm_board->compatible);
+
+	if (board.dtb == NULL) {
+		putstr("NO DTB BLOB FOUND FOR ");
+		putstr(bcm_board->compatible);
+		putstr("\n");
+		panic(); /* doesn't return */
+	}
+
+	return &board;
+}

--- a/configs/Makefile.config.bcm63xx
+++ b/configs/Makefile.config.bcm63xx
@@ -1,0 +1,12 @@
+# config for Broadcom BCM63xx (ARM-based) xDSL boards
+
+MFG=bcm63xx
+UART=bcm63xx
+UART_PORT=0
+BINFMT=elf32-littlearm
+LOADADDR=0x8000
+UART_BASE=0xfffe8600
+APPEND_KERNEL=input/zImage
+APPEND_DTBS=input/bcm963138dvt.dtb
+LIBFDT = y
+NR_BANKS=8

--- a/matcher.lds
+++ b/matcher.lds
@@ -1,5 +1,9 @@
+PHDRS {
+	text PT_LOAD FLAGS(7);
+}
+
 SECTIONS {
-	.text : { * (.text_main); * (.text); }
+	.text : { * (.text_main); * (.text); }:text = 0
 	.data : { * (.data); }
 	.rodata : { * (.rodata); }
 	.bss :

--- a/serial-bcm63xx.c
+++ b/serial-bcm63xx.c
@@ -1,0 +1,30 @@
+#include "types.h"
+#include "register.h"
+#include "serial.h"
+
+#define UART_IR_REG			0x10
+#define UART_IR_STAT(x)			(1 << (x))
+#define UART_IR_TXEMPTY			5
+#define UART_FIFO_REG			0x14
+
+/* Implementation ripped from arch/mips/bcm63xx/early_printk.c. Thanks to
+ * Maxime Bizon for the original code.
+ */
+static void wait_xfered(void)
+{
+	unsigned int val;
+
+	/* wait for any previous char to be transmitted */
+	do {
+		val = readl(UART_BASE + UART_IR_REG);
+		if (val & UART_IR_STAT(UART_IR_TXEMPTY))
+			break;
+	} while (1);
+}
+
+void __putch(char c)
+{
+	wait_xfered();
+	writel(c, UART_BASE + UART_FIFO_REG);
+	wait_xfered();
+}


### PR DESCRIPTION
This pull request adds support for Broadcom's BCM63xx xDSL SoCs, specifically BCM63138. Here is a bootlog example:

CFE> r  
0x8000/11422008 0xaec938/12 Entry at 0x00008000  
Closing network.  
rdd_ring_destroy  
 Starting program at 0x00008000  
++ Impedance Matcher heads/bcm63xx-0-g0dea3494877e-dirty (3rd stage loader) ++                  

Found a Broadcom BCM00063138 chip  
Detected board: brcm,bcm63138  
Booting into Linux kernel ...  
Uncompressing Linux... done, booting the kernel.  
...
