### PR TITLE
Fix build after updating find_dtb() signature

### DIFF
--- a/board-bcm63xx.c
+++ b/board-bcm63xx.c
@@ -61,7 +61,8 @@ struct board *match_board(u32 machid, const struct tag *tags)
 
 	board.kernel = &_binary_input_zImage_start;
 	board.compatible = bcm_board->compatible;
-	board.dtb = find_dtb(&_binary_dtbs_bin_start, bcm_board->compatible);
+	board.dtb = find_dtb(&_binary_dtbs_bin_start, bcm_board->compatible,
+			     &board.dtb_size);
 
 	if (board.dtb == NULL) {
 		putstr("NO DTB BLOB FOUND FOR ");

--- a/board-dreamplug.c
+++ b/board-dreamplug.c
@@ -22,7 +22,8 @@ struct board *match_board(u32 machid, const struct tag *tags)
 	/* testing zImage linked in and dtbs appended */
 	board.kernel = &_binary_input_zImage_start;
 	board.compatible = compat;
-	board.dtb = find_dtb(&_binary_dtbs_bin_start, compat);
+	board.dtb = find_dtb(&_binary_dtbs_bin_start, compat,
+			     &board.dtb_size);
 
 	return &board;
 }

--- a/board-exynos.c
+++ b/board-exynos.c
@@ -64,7 +64,8 @@ struct board *match_board(u32 machid, const struct tag *tags)
 
 	board.kernel = &_binary_input_zImage_start;
 	board.compatible = exboard->compatible;
-	board.dtb = find_dtb(&_binary_dtbs_bin_start, exboard->compatible);
+	board.dtb = find_dtb(&_binary_dtbs_bin_start, exboard->compatible,
+			     &board.dtb_size);
 
 	if (board.dtb == NULL) {
 		putstr("NO DTB BLOB FOUND FOR ");


### PR DESCRIPTION
All boards except board-raumfeld.c would fail to build because they are
not passing a 3rd argument to find_dtb(), fix that.

Fixes: 6a3a58ae7af7 ("Store dtb size in board struct")
Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>