### PR TITLE
boards: bcm63xx: Match BCM63148

### DIFF
--- a/board-bcm63xx.c
+++ b/board-bcm63xx.c
@@ -20,6 +20,10 @@ static struct bcm63xx_board boards[] = {
 		.chip_id	= 0x63138,
 		.compatible	= "brcm,bcm63138",
 	},
+	{
+		.chip_id	= 0x63148,
+		.compatible	= "brcm,bcm63148",
+	},
 	{ 0, NULL }	/* sentinel */
 };
 


### PR DESCRIPTION
BCM63148 is another DSL chip with a different CPU complex that requires
a special DTB, add a matching entry for it.

Signed-off-by: Florian Fainelli <f.fainelli@gmail.com>